### PR TITLE
introduce other optional reference ellipsoids

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The default units are:
 
 We support several reference ellipsoids,
 [WGS84](https://en.wikipedia.org/wiki/World_Geodetic_System#A_new_World_Geodetic_System:_WGS_84)
-is defined as the default one the default one, obtained with `Ellipsoid::default()`.
+is defined as the default one, obtained with `Ellipsoid::default()`.
 
 List of coordinates systems implemented in the functions:
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ The default units are:
 - Meters  [m] for linear variables
 - [Greenwich Sidereal Time](https://www.cfa.harvard.edu/~jzhao/times.html)  [GST] for date and time
 
-The default reference ellipsoid is the [WGS84](https://en.wikipedia.org/wiki/World_Geodetic_System#A_new_World_Geodetic_System:_WGS_84)
+We support 4 reference ellipsoids at the moment, and
+[WGS84](https://en.wikipedia.org/wiki/World_Geodetic_System#A_new_World_Geodetic_System:_WGS_84).
+is the default one, obtained with `Reference::default()`.
 
 List of coordinates systems implemented in the functions:
 
@@ -34,8 +36,7 @@ Additional functions:
 - 3x3 Matrix - 3x1 column multiplication
 - 3x3 Matrix transpose
 - f64 round towards zero 
-
-
+- projected distance (`Haversine` formula) between two coordinates (lat, lon, in decimal degrees)
 
 ## To-Do List:
 

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ The default units are:
 - Meters  [m] for linear variables
 - [Greenwich Sidereal Time](https://www.cfa.harvard.edu/~jzhao/times.html)  [GST] for date and time
 
-We support 4 reference ellipsoids at the moment, and
+We support several reference ellipsoids,
 [WGS84](https://en.wikipedia.org/wiki/World_Geodetic_System#A_new_World_Geodetic_System:_WGS_84)
-is the default one, obtained with `Reference::default()`.
+is defined as the default one the default one, obtained with `Ellipsoid::default()`.
 
 List of coordinates systems implemented in the functions:
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The default units are:
 - [Greenwich Sidereal Time](https://www.cfa.harvard.edu/~jzhao/times.html)  [GST] for date and time
 
 We support 4 reference ellipsoids at the moment, and
-[WGS84](https://en.wikipedia.org/wiki/World_Geodetic_System#A_new_World_Geodetic_System:_WGS_84).
+[WGS84](https://en.wikipedia.org/wiki/World_Geodetic_System#A_new_World_Geodetic_System:_WGS_84)
 is the default one, obtained with `Reference::default()`.
 
 List of coordinates systems implemented in the functions:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -523,12 +523,21 @@ pub enum Ellipsoid {
     /// semi-major axis: 6378137.0 [m]  
     /// flattening: 1.0/298.2572235630
     WGS84,
+    /// WGS72: semi-major axis: 6378135.0 [m]    
+    /// flattening: 1.0/298.26
+    WGS72,
+    /// WGS66: semi-major axis: 6378145.0 [m]    
+    /// flattening: 1.0/298.25
+    WGS66,
+    /// WGS60: semi-major axis: 6378165.0 [m]    
+    /// flattening: 1.0/298.3
+    WGS60,
     /// ZP90: Glonass Ellipsoid frame  
-    /// semi-major axis: 6378136.0 [m]  
+    /// semi-major axis: 6378136.0 [m] 
     /// flattening: 1/298.257839303
     ZP90,
-    /// BDC: Beidou Coordinate System  
-    /// semi-major axis: 6378137.0 [m]  
+    /// BDC: Beidou Coordinate System   
+    /// semi-major axis: 6378137.0 [m] 
     /// flattening: 1/298.257222101
     BDC,
     /// GRS80 reference ellipsoid  
@@ -554,6 +563,9 @@ impl Ellipsoid {
     pub fn parameters(&self) -> (f64,f64,f64,f64) {
         let (major, flattening): (f64, f64) = match self {
             Ellipsoid::WGS84 => (6378137.0, 1.0/298.257223563),
+            Ellipsoid::WGS72 => (6378135.0, 1.0/298.26),
+            Ellipsoid::WGS66 => (6378145.0, 1.0/298.25),
+            Ellipsoid::WGS60 => (6378165.0, 1.0/298.3),
             Ellipsoid::ZP90 =>  (6378136.0, 1.0/298.257839303),
             Ellipsoid::BDC =>   (6378137.0, 1.0/298.257222101),
             Ellipsoid::GRS80 => (6378137.0, 1.0/298.2572221009),
@@ -1074,6 +1086,15 @@ mod tests {
         assert!((b-6356752.314245).abs() < 1E-6);
         assert!((1.0/f-298.257223563).abs() < 1E-6);
         assert!((e-6.6943799E-3_f64).abs() < 1E-6);
+        let (a, b, f, e) = Ellipsoid::WGS72.parameters();
+        assert!((b-a*(1.0-f)).abs() < 1E-6);
+        assert!((e-(f*(2.0-f))) < 1E-6);
+        let (a, b, f, e) = Ellipsoid::WGS66.parameters();
+        assert!((b-a*(1.0-f)).abs() < 1E-6);
+        assert!((e-(f*(2.0-f))) < 1E-6);
+        let (a, b, f, e) = Ellipsoid::WGS60.parameters();
+        assert!((b-a*(1.0-f)).abs() < 1E-6);
+        assert!((e-(f*(2.0-f))) < 1E-6);
         let (a, b, f, e) = Ellipsoid::ZP90.parameters();
         assert!((a-6378136.0).abs() < 1E-6);
         assert!((b-a*(1.0-f)).abs() < 1E-6);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -544,6 +544,18 @@ pub enum Ellipsoid {
     /// semi-major axis: 6378137.0 [m]  
     /// flattening: 1.0/298.257222101
     GRS80,
+    /// Bessel reference ellipsoid   
+    /// semi-major axis: 6377397.155 [m] 
+    /// flattening: 1.0/299.1528128
+    Bessel,
+    /// Airy reference ellipsoid   
+    /// semi-major axis: 6377563.396 [m]  
+    /// flattening: 1.0/299.3249646
+    Airy,
+    /// International reference ellipsoid   
+    /// semi-major axis: 6378388.0 [m]  
+    /// flattening: 1.0/297.0
+    International,
 }
 
 impl Default for Ellipsoid {
@@ -569,6 +581,9 @@ impl Ellipsoid {
             Ellipsoid::ZP90 =>  (6378136.0, 1.0/298.257839303),
             Ellipsoid::BDC =>   (6378137.0, 1.0/298.257222101),
             Ellipsoid::GRS80 => (6378137.0, 1.0/298.2572221009),
+            Ellipsoid::Bessel =>(6377397.155, 299.1528128),
+            Ellipsoid::Airy  => (6377563.396, 299.3249646),
+            Ellipsoid::International => (6378388.0, 297.0),
         };
 
         let minor = major * (1.0 - flattening);
@@ -1109,6 +1124,15 @@ mod tests {
         assert!((a-6378137.0).abs() < 1E-6);
         assert!((b-a*(1.0-f)).abs() < 1E-6);
         assert!((1.0/f-298.257222101).abs() < 1E-6);
+        assert!((e-(f*(2.0-f))) < 1E-6);
+        let (a, b, f, e) = Ellipsoid::Bessel.parameters();
+        assert!((b-a*(1.0-f)).abs() < 1E-6);
+        assert!((e-(f*(2.0-f))) < 1E-6);
+        let (a, b, f, e) = Ellipsoid::International.parameters();
+        assert!((b-a*(1.0-f)).abs() < 1E-6);
+        assert!((e-(f*(2.0-f))) < 1E-6);
+        let (a, b, f, e) = Ellipsoid::Airy.parameters();
+        assert!((b-a*(1.0-f)).abs() < 1E-6);
         assert!((e-(f*(2.0-f))) < 1E-6);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,6 +33,7 @@ pub fn geodetic2ecef(lat: f64, lon: f64, alt: f64, r_ellips: Ellipsoid) -> (f64,
 /// - lat0 = reference latitude [rad]
 /// - lon0 = reference longitude [rad]
 /// - alt0 = reference altitude [m]
+/// - r_ellips = reference ellipsoid, defaults ref. frame is WGS84 
 /// 
 /// ## Outputs:
 /// - az = azimuth angle [rad] of input geodetic location from reference geodetic location
@@ -54,6 +55,7 @@ pub fn geodetic2aer(lat: f64, lon: f64, alt: f64,lat0: f64, lon0: f64, alt0: f64
 /// - lat0 = reference latitude [rad]
 /// - lon0 = reference longitude [rad]
 /// - alt0 = reference altitude [m]
+/// - r_ellips = reference ellipsoid, defaults ref. frame is WGS84 
 /// 
 /// ## Outputs:
 /// - e = east coordinate [m] of input geodetic location from reference geodetic location
@@ -77,6 +79,7 @@ pub fn geodetic2enu(lat: f64, lon: f64, alt: f64,lat0: f64, lon0: f64, alt0: f64
 /// - lat0 = reference latitude [rad]
 /// - lon0 = reference longitude [rad]
 /// - alt0 = reference altitude [m]
+/// - r_ellips = reference ellipsoid, defaults ref. frame is WGS84 
 /// 
 /// ## Outputs:
 /// - n = north coordinate [m] of input geodetic location from reference geodetic location
@@ -96,6 +99,7 @@ pub fn geodetic2ned(lat: f64, lon: f64, alt: f64,lat0: f64, lon0: f64, alt0: f64
 /// - lat0 = reference latitude [rad]
 /// - lon0 = reference longitude [rad]
 /// - alt0 = reference altitude [m]
+/// - r_ellips = reference ellipsoid, defaults ref. frame is WGS84 
 /// 
 /// ## Outputs:
 /// - x = x ECEF coordinate [m]
@@ -134,6 +138,7 @@ pub fn aer2enu(az : f64, el: f64,slant_range :f64) -> (f64,f64,f64){
 /// - lat0 = reference latitude [rad]
 /// - lon0 = reference longitude [rad]
 /// - alt0 = reference altitude [m]
+/// - r_ellips = reference ellipsoid, defaults ref. frame is WGS84 
 /// 
 /// ## Outputs:
 /// - x = x ECI coordinate [m]
@@ -169,6 +174,7 @@ pub fn aer2ned(az : f64, el: f64,slant_range :f64) -> (f64,f64,f64){
 /// - lat0 = reference latitude [rad]
 /// - lon0 = reference longitude [rad]
 /// - alt0 = reference altitude [m]
+/// - r_ellips = reference ellipsoid, defaults ref. frame is WGS84 
 /// 
 /// ## Outputs:
 /// - lat = input latitude [rad]
@@ -232,6 +238,7 @@ pub fn enu2aer(e : f64, n: f64,u :f64) -> (f64,f64,f64){
 /// - lat0 = reference latitude [rad]
 /// - lon0 = reference longitude [rad]
 /// - alt0 = reference altitude [m]
+/// - r_ellips = reference ellipsoid, defaults ref. frame is WGS84 
 /// 
 /// ## Outputs:
 /// - x = x ECEF coordinate [m]
@@ -253,6 +260,7 @@ pub fn enu2ecef(e : f64, n: f64, u: f64, lat0: f64, lon0: f64, alt0: f64, r_elli
 /// - lat0 = reference latitude [rad]
 /// - lon0 = reference longitude [rad]
 /// - alt0 = reference altitude [m]
+/// - r_ellips = reference ellipsoid, defaults ref. frame is WGS84 
 /// ## Outputs:
 /// - lat = latitude [rad]
 /// - lon = longitude [rad]
@@ -336,6 +344,7 @@ pub fn ecef2geodetic(x: f64, y: f64, z: f64, r_ellips: Ellipsoid) -> (f64,f64,f6
 /// - lat0 = reference latitude [rad]
 /// - lon0 = reference longitude [rad]
 /// - alt0 = reference altitude [m]
+/// - r_ellips = reference ellipsoid, defaults ref. frame is WGS84 
 /// 
 /// ## Outputs:
 /// - e = east coordinate [m] of input ECEF location from reference geodetic location
@@ -356,6 +365,7 @@ pub fn ecef2enu(x: f64, y: f64, z: f64, lat0: f64, lon0: f64, alt0: f64, r_ellip
 /// - lat0 = reference latitude [rad]
 /// - lon0 = reference longitude [rad]
 /// - alt0 = reference altitude [m]
+/// - r_ellips = reference ellipsoid, defaults ref. frame is WGS84 
 /// 
 /// ## Outputs:
 /// - n = north coordinate [m] of input location from reference geodetic location
@@ -396,6 +406,7 @@ pub fn uvw2enu(u : f64, v: f64,w :f64, lat0: f64, lon0: f64) -> (f64,f64,f64){
 /// - lat0 = reference latitude [rad]
 /// - lon0 = reference longitude [rad]
 /// - alt0 = reference altitude [m]
+/// - r_ellips = reference ellipsoid, defaults ref. frame is WGS84 
 /// 
 /// ## Outputs:
 /// - az = azimuth angle [rad] of input location from reference geodetic location
@@ -417,6 +428,7 @@ pub fn ecef2aer(x: f64, y: f64, z: f64, lat0: f64, lon0: f64, alt0: f64, r_ellip
 /// - lat = reference latitude [rad]
 /// - lon = reference longitude [rad]
 /// - alt = reference altitude [m]
+/// - r_ellips = reference ellipsoid, defaults ref. frame is WGS84 
 /// 
 /// ## Outputs:
 /// - az = azimuth angle [rad] of input location from reference geodetic location
@@ -470,6 +482,7 @@ pub fn ned2aer(n : f64, e: f64,d :f64) -> (f64,f64,f64){
 /// - lat0 = reference latitude [rad]
 /// - lon0 = reference longitude [rad]
 /// - alt0 = reference altitude [m]
+/// - r_ellips = reference ellipsoid, defaults ref. frame is WGS84 
 /// 
 /// ## Outputs:
 /// - lat = latitude [rad]
@@ -489,6 +502,7 @@ pub fn ned2geodetic(n : f64, e: f64,d :f64, lat0: f64, lon0: f64, alt0: f64, r_e
 /// - lat0 = reference latitude [rad]
 /// - lon0 = reference longitude [rad]
 /// - alt0 = reference altitude [m]
+/// - r_ellips = reference ellipsoid, defaults ref. frame is WGS84 
 /// 
 /// ## Outputs:
 /// - x = x ECEF coordinate [m]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,7 @@
 /// - x = x ECEF coordinate [m]
 /// - y = y ECEF coordinate [m]
 /// - z = z ECEF coordinate [m]
-pub fn geodetic2ecef(lat: f64, lon: f64, alt: f64, r_ellips: Reference) -> (f64,f64,f64){
+pub fn geodetic2ecef(lat: f64, lon: f64, alt: f64, r_ellips: Ellipsoid) -> (f64,f64,f64){
     let n = get_radius_normal(lat, r_ellips);
     let (major,minor,_,_) = r_ellips.parameters();
 
@@ -38,7 +38,7 @@ pub fn geodetic2ecef(lat: f64, lon: f64, alt: f64, r_ellips: Reference) -> (f64,
 /// - az = azimuth angle [rad] of input geodetic location from reference geodetic location
 /// - el = elevation angle [rad] of input geodetic location from reference geodetic location
 /// - slant_range = slant range [m] of input geodetic location from reference geodetic location
-pub fn geodetic2aer(lat: f64, lon: f64, alt: f64,lat0: f64, lon0: f64, alt0: f64, r_ellips: Reference) -> (f64,f64,f64){
+pub fn geodetic2aer(lat: f64, lon: f64, alt: f64,lat0: f64, lon0: f64, alt0: f64, r_ellips: Ellipsoid) -> (f64,f64,f64){
     let (e,n,u) = geodetic2enu(lat,lon,alt,lat0,lon0,alt0,r_ellips);
     let (az,el,slant_range) = enu2aer(e, n, u);
 
@@ -59,7 +59,7 @@ pub fn geodetic2aer(lat: f64, lon: f64, alt: f64,lat0: f64, lon0: f64, alt0: f64
 /// - e = east coordinate [m] of input geodetic location from reference geodetic location
 /// - n = north coordinate [m] of input geodetic location from reference geodetic location
 /// - u = up coordinate [m] of input geodetic location from reference geodetic location
-pub fn geodetic2enu(lat: f64, lon: f64, alt: f64,lat0: f64, lon0: f64, alt0: f64, r_ellips: Reference) -> (f64,f64,f64){
+pub fn geodetic2enu(lat: f64, lon: f64, alt: f64,lat0: f64, lon0: f64, alt0: f64, r_ellips: Ellipsoid) -> (f64,f64,f64){
     let (x1,y1,z1) = geodetic2ecef(lat, lon, alt, r_ellips);
     let (x2,y2,z2) = geodetic2ecef(lat0, lon0, alt0, r_ellips);
 
@@ -82,7 +82,7 @@ pub fn geodetic2enu(lat: f64, lon: f64, alt: f64,lat0: f64, lon0: f64, alt0: f64
 /// - n = north coordinate [m] of input geodetic location from reference geodetic location
 /// - e = east coordinate [m] of input geodetic location from reference geodetic location
 /// - d = down coordinate [m] of input geodetic location from reference geodetic location
-pub fn geodetic2ned(lat: f64, lon: f64, alt: f64,lat0: f64, lon0: f64, alt0: f64, r_ellips: Reference) -> (f64,f64,f64){
+pub fn geodetic2ned(lat: f64, lon: f64, alt: f64,lat0: f64, lon0: f64, alt0: f64, r_ellips: Ellipsoid) -> (f64,f64,f64){
     let enu =  geodetic2enu(lat, lon, alt, lat0, lon0, alt0, r_ellips);
     (enu.1,enu.0,-enu.2)
 }
@@ -101,7 +101,7 @@ pub fn geodetic2ned(lat: f64, lon: f64, alt: f64,lat0: f64, lon0: f64, alt0: f64
 /// - x = x ECEF coordinate [m]
 /// - y = y ECEF coordinate [m]
 /// - z = z ECEF coordinate [m]
-pub fn aer2ecef(az : f64, el: f64,slant_range :f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Reference)-> (f64,f64,f64){
+pub fn aer2ecef(az : f64, el: f64,slant_range :f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Ellipsoid)-> (f64,f64,f64){
 
     let (x0,y0,z0) = geodetic2ecef(lat0, lon0, alt0, r_ellips);
     let (e,n,u) = aer2enu(az,el,slant_range);
@@ -139,7 +139,7 @@ pub fn aer2enu(az : f64, el: f64,slant_range :f64) -> (f64,f64,f64){
 /// - x = x ECI coordinate [m]
 /// - y = y ECI coordinate [m]
 /// - z = z ECI coordinate [m]
-pub fn aer2eci(gst :f64, az : f64, el: f64,slant_range :f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Reference) -> (f64,f64,f64){
+pub fn aer2eci(gst :f64, az : f64, el: f64,slant_range :f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Ellipsoid) -> (f64,f64,f64){
     let (x1,y1,z1) = aer2ecef(az, el, slant_range, lat0, lon0, alt0, r_ellips);
     ecef2eci(gst, x1, y1, z1)
 }
@@ -174,7 +174,7 @@ pub fn aer2ned(az : f64, el: f64,slant_range :f64) -> (f64,f64,f64){
 /// - lat = input latitude [rad]
 /// - lon = input longitude [rad]
 /// - alt = input altitude [m]
-pub fn aer2geodetic(az : f64, el: f64,slant_range :f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Reference)-> (f64,f64,f64) {
+pub fn aer2geodetic(az : f64, el: f64,slant_range :f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Ellipsoid)-> (f64,f64,f64) {
     let (x,y,z) = aer2ecef(az, el, slant_range, lat0, lon0, alt0, r_ellips);
     ecef2geodetic(x,y,z,r_ellips)
 }
@@ -237,7 +237,7 @@ pub fn enu2aer(e : f64, n: f64,u :f64) -> (f64,f64,f64){
 /// - x = x ECEF coordinate [m]
 /// - y = y ECEF coordinate [m]
 /// - z = z ECEF coordinate [m]
-pub fn enu2ecef(e : f64, n: f64, u: f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Reference) -> (f64,f64,f64){
+pub fn enu2ecef(e : f64, n: f64, u: f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Ellipsoid) -> (f64,f64,f64){
     let (x0,y0,z0) = geodetic2ecef(lat0, lon0, alt0, r_ellips);
     let (dx,dy,dz) = enu2uvw(e, n, u, lat0, lon0);
 
@@ -257,7 +257,7 @@ pub fn enu2ecef(e : f64, n: f64, u: f64, lat0: f64, lon0: f64, alt0: f64, r_elli
 /// - lat = latitude [rad]
 /// - lon = longitude [rad]
 /// - alt = altitude [m]
-pub fn enu2geodetic(e : f64, n: f64,u :f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Reference) -> (f64,f64,f64){
+pub fn enu2geodetic(e : f64, n: f64,u :f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Ellipsoid) -> (f64,f64,f64){
     let (x,y,z) = enu2ecef(e, n, u, lat0, lon0, alt0, r_ellips);
     let (lat,lon,alt) = ecef2geodetic(x, y, z, r_ellips);
 
@@ -294,7 +294,7 @@ pub fn ecef2eci(gst :f64,x: f64, y: f64, z: f64) -> (f64,f64,f64){
 /// - lat = latitude [rad]
 /// - lon = longitude [rad]
 /// - alt = altitude [m]
-pub fn ecef2geodetic(x: f64, y: f64, z: f64, r_ellips: Reference) -> (f64,f64,f64){
+pub fn ecef2geodetic(x: f64, y: f64, z: f64, r_ellips: Ellipsoid) -> (f64,f64,f64){
     let (major, minor, _,_) = r_ellips.parameters();
 
     let r = (x*x+y*y+z*z).sqrt();
@@ -341,7 +341,7 @@ pub fn ecef2geodetic(x: f64, y: f64, z: f64, r_ellips: Reference) -> (f64,f64,f6
 /// - e = east coordinate [m] of input ECEF location from reference geodetic location
 /// - n = north coordinate [m] of input ECEF location from reference geodetic location
 /// - u = up coordinate [m] of input ECEF location from reference geodetic location
-pub fn ecef2enu(x: f64, y: f64, z: f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Reference)-> (f64,f64,f64){
+pub fn ecef2enu(x: f64, y: f64, z: f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Ellipsoid)-> (f64,f64,f64){
     let (x0,y0,z0) = geodetic2ecef(lat0, lon0, alt0,r_ellips);
     let (e,n,u) = uvw2enu(x-x0,y-y0,z-z0,lat0,lon0);
     (e,n,u)
@@ -361,7 +361,7 @@ pub fn ecef2enu(x: f64, y: f64, z: f64, lat0: f64, lon0: f64, alt0: f64, r_ellip
 /// - n = north coordinate [m] of input location from reference geodetic location
 /// - e = east coordinate [m] of input location from reference geodetic location
 /// - d = down coordinate [m] of input location from reference geodetic location
-pub fn ecef2ned(x: f64, y: f64, z: f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Reference)-> (f64,f64,f64){
+pub fn ecef2ned(x: f64, y: f64, z: f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Ellipsoid)-> (f64,f64,f64){
     let enu = ecef2enu(x, y, z, lat0, lon0, alt0, r_ellips);
     (enu.1,enu.0,-enu.2)
 }
@@ -401,7 +401,7 @@ pub fn uvw2enu(u : f64, v: f64,w :f64, lat0: f64, lon0: f64) -> (f64,f64,f64){
 /// - az = azimuth angle [rad] of input location from reference geodetic location
 /// - el = elevation angle [rad] of input location from reference geodetic location
 /// - slant_range = slant range [m] of input location from reference geodetic location
-pub fn ecef2aer(x: f64, y: f64, z: f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Reference)-> (f64,f64,f64){
+pub fn ecef2aer(x: f64, y: f64, z: f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Ellipsoid)-> (f64,f64,f64){
     let (e,n,u) = ecef2enu(x, y, z, lat0, lon0, alt0, r_ellips);
     let (az,el,slant_range) = enu2aer(e,n,u);
 
@@ -422,7 +422,7 @@ pub fn ecef2aer(x: f64, y: f64, z: f64, lat0: f64, lon0: f64, alt0: f64, r_ellip
 /// - az = azimuth angle [rad] of input location from reference geodetic location
 /// - el = elevation angle [rad] of input location from reference geodetic location
 /// - slant_range = slant range [m] of input location from reference geodetic location
-pub fn eci2aer(gst :f64,x: f64, y: f64, z: f64, lat :f64, lon :f64, alt :f64, r_ellips: Reference)-> (f64,f64,f64){
+pub fn eci2aer(gst :f64,x: f64, y: f64, z: f64, lat :f64, lon :f64, alt :f64, r_ellips: Ellipsoid)-> (f64,f64,f64){
     let (x,y,z) = eci2ecef(gst, x, y, z);
     let (az,el,slant_range) = ecef2aer(x, y, z, lat, lon, alt, r_ellips);
     (az,el,slant_range)
@@ -475,7 +475,7 @@ pub fn ned2aer(n : f64, e: f64,d :f64) -> (f64,f64,f64){
 /// - lat = latitude [rad]
 /// - lon = longitude [rad]
 /// - alt = altitude [m]
-pub fn ned2geodetic(n : f64, e: f64,d :f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Reference) -> (f64,f64,f64){
+pub fn ned2geodetic(n : f64, e: f64,d :f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Ellipsoid) -> (f64,f64,f64){
     let geo = enu2geodetic(e, n, -d, lat0, lon0, alt0, r_ellips);
     geo
 }
@@ -494,7 +494,7 @@ pub fn ned2geodetic(n : f64, e: f64,d :f64, lat0: f64, lon0: f64, alt0: f64, r_e
 /// - x = x ECEF coordinate [m]
 /// - y = y ECEF coordinate [m]
 /// - z = z ECEF coordinate [m]
-pub fn ned2ecef(n: f64,e : f64, d :f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Reference) -> (f64,f64,f64){
+pub fn ned2ecef(n: f64,e : f64, d :f64, lat0: f64, lon0: f64, alt0: f64, r_ellips: Ellipsoid) -> (f64,f64,f64){
     let ecef = enu2ecef(e, n, -d, lat0, lon0, alt0, r_ellips);
     ecef
 }
@@ -518,12 +518,12 @@ pub fn transpose3(x: [f64;9]) -> [f64;9] {
 }
 
 #[derive(Debug, Copy, Clone)]
-pub enum Reference {
-    /// WGS84: GPS Reference frame  
+pub enum Ellipsoid {
+    /// WGS84: GPS Ellipsoid frame  
     /// semi-major axis: 6378137.0 [m]  
     /// flattening: 1.0/298.2572235630
     Wgs84,
-    /// ZP90: Glonass Reference frame  
+    /// ZP90: Glonass Ellipsoid frame  
     /// semi-major axis: 6378136.0 [m]  
     /// flattening: 1/298.257839303
     Zp90,
@@ -537,14 +537,14 @@ pub enum Reference {
     Grs80,
 }
 
-impl Default for Reference {
-    fn default() -> Reference {
-        Reference::Wgs84
+impl Default for Ellipsoid {
+    fn default() -> Ellipsoid {
+        Ellipsoid::Wgs84
     }
 }
 
-impl Reference {
-    /// Returns the tuple representing the Reference frame.
+impl Ellipsoid {
+    /// Returns the tuple representing the Ellipsoid frame.
     /// 
     /// ## Outputs:
     /// - tuple.0 = semi-major axis [m]
@@ -553,10 +553,10 @@ impl Reference {
     /// - tuple.3 = squared eccentricity [rad^2]
     pub fn parameters(&self) -> (f64,f64,f64,f64) {
         let (major, flattening): (f64, f64) = match self {
-            Reference::Wgs84 => (6378137.0, 1.0/298.257223563),
-            Reference::Zp90 =>  (6378136.0, 1.0/298.257839303),
-            Reference::Bdc =>   (6378137.0, 1.0/298.257222101),
-            Reference::Grs80 => (6378137.0, 1.0/298.2572221009),
+            Ellipsoid::Wgs84 => (6378137.0, 1.0/298.257223563),
+            Ellipsoid::Zp90 =>  (6378136.0, 1.0/298.257839303),
+            Ellipsoid::Bdc =>   (6378137.0, 1.0/298.257222101),
+            Ellipsoid::Grs80 => (6378137.0, 1.0/298.2572221009),
         };
 
         let minor = major * (1.0 - flattening);
@@ -567,7 +567,7 @@ impl Reference {
 
 /// Returns the normal radius based on given latitude
 /// and desired reference frame
-pub fn get_radius_normal(lat: f64, r_ellips: Reference)->f64 {
+pub fn get_radius_normal(lat: f64, r_ellips: Ellipsoid)->f64 {
     let (major,_,_,squared_eccentricity) = r_ellips.parameters();
     major/((1.0-squared_eccentricity*lat.sin()*lat.sin()).sqrt())
 }
@@ -704,7 +704,7 @@ mod tests {
         let lon = deg2rad(91.38733072);
         let alt = 4031.0;
 
-        let (x,y,z) = geodetic2ecef(lat,lon,alt, Reference::default());
+        let (x,y,z) = geodetic2ecef(lat,lon,alt, Ellipsoid::default());
 
         let xref = -1.337281037300386e+05;
         let yref = 5.521796910920261e+06;
@@ -730,7 +730,7 @@ mod tests {
         let elref = deg2rad(69.999999999945540);
         let rangeref = 1000.0;
 
-        let (a,e,r) = geodetic2aer(lat, lon, alt, lat0, lon0, alt0, Reference::default());
+        let (a,e,r) = geodetic2aer(lat, lon, alt, lat0, lon0, alt0, Ellipsoid::default());
 
         assert!((a-azref).abs()<1e-3);
         assert!((e-elref).abs()<1e-3);
@@ -751,7 +751,7 @@ mod tests {
         let nref = 2.868422278521820e+02;
         let uref = 9.396926207845534e+02;
 
-        let (e,n,u) = geodetic2enu(lat, lon, alt, lat0, lon0, alt0, Reference::default());
+        let (e,n,u) = geodetic2enu(lat, lon, alt, lat0, lon0, alt0, Ellipsoid::default());
 
         assert!((e-eref).abs()<1e-3);
         assert!((n-nref).abs()<1e-3);
@@ -768,7 +768,7 @@ mod tests {
         let el = deg2rad(70.0);
         let slant_range = 1000.0;
 
-        let (x,y,z) = aer2ecef(az,el,slant_range,lat0,lon0,alt0, Reference::default());
+        let (x,y,z) = aer2ecef(az,el,slant_range,lat0,lon0,alt0, Ellipsoid::default());
 
 
         let xref = 6.609301927610816e+05;
@@ -812,7 +812,7 @@ mod tests {
         let yref = -4.836588977863766e+07;
         let zref = -3.143285462295778e+07;
 
-        let (x,y,z) = aer2eci(gst, az, el, slant_range, lat0, lon0, alt0, Reference::default());
+        let (x,y,z) = aer2eci(gst, az, el, slant_range, lat0, lon0, alt0, Ellipsoid::default());
 
         assert!((x-xref).abs()<1e-3);
         assert!((y-yref).abs()<1e-3);
@@ -834,7 +834,7 @@ mod tests {
         let altref = 1.139701799575106e+03;
         
 
-        let (lat,lon,alt) = aer2geodetic(az, el, slant_range, lat0, lon0, alt0, Reference::default());
+        let (lat,lon,alt) = aer2geodetic(az, el, slant_range, lat0, lon0, alt0, Ellipsoid::default());
 
         assert!((lat-latref).abs()<1e-8);
         assert!((lon-lonref).abs()<1e-8);
@@ -871,7 +871,7 @@ mod tests {
         let yref = -4.701424222957011e+06;
         let zref = 4.246579604632881e+06;
         
-        let (x,y,z) = enu2ecef(e, n, u, lat0, lon0, alt0, Reference::default());
+        let (x,y,z) = enu2ecef(e, n, u, lat0, lon0, alt0, Ellipsoid::default());
 
         assert!((x-xref).abs()<1e-3);
         assert!((y-yref).abs()<1e-3);
@@ -891,7 +891,7 @@ mod tests {
         let lonref = deg2rad(-82.0);
         let altref = 1.990000000007368e+02;
 
-        let (lat,lon,alt) = enu2geodetic(e, n, u, lat0, lon0, alt0, Reference::default());
+        let (lat,lon,alt) = enu2geodetic(e, n, u, lat0, lon0, alt0, Ellipsoid::default());
 
         assert!((lat-latref).abs()<1e-8);
         assert!((lon-lonref).abs()<1e-8);
@@ -904,15 +904,15 @@ mod tests {
         let lonref = deg2rad(91.38733072);
         let altref = 4031.0;
 
-        let (x,y,z) = geodetic2ecef(latref, lonref, altref, Reference::default());
-        let (lat,lon,alt) = ecef2geodetic(x, y, z, Reference::default());
+        let (x,y,z) = geodetic2ecef(latref, lonref, altref, Ellipsoid::default());
+        let (lat,lon,alt) = ecef2geodetic(x, y, z, Ellipsoid::default());
         
         assert!((lat-latref).abs()<1e-8);
         assert!((lon-lonref).abs()<1e-8);
         assert!((alt-altref).abs()<1e-8);
 
-        let (x,y,z) = geodetic2ecef(latref, lonref, altref-5000.0, Reference::default());
-        let (lat,lon,alt) = ecef2geodetic(x, y, z, Reference::default());
+        let (x,y,z) = geodetic2ecef(latref, lonref, altref-5000.0, Ellipsoid::default());
+        let (lat,lon,alt) = ecef2geodetic(x, y, z, Ellipsoid::default());
         
         assert!((lat-latref).abs()<1e-8);
         assert!((lon-lonref).abs()<1e-8);
@@ -928,8 +928,8 @@ mod tests {
         let nref = 2.868422200000000e+02;
         let uref = 9.396926200000000e+02;
         
-        let (x,y,z) = enu2ecef(eref, nref, uref, lat0, lon0, alt0, Reference::default());
-        let (e,n,u)= ecef2enu(x, y, z, lat0, lon0, alt0, Reference::default());
+        let (x,y,z) = enu2ecef(eref, nref, uref, lat0, lon0, alt0, Ellipsoid::default());
+        let (e,n,u)= ecef2enu(x, y, z, lat0, lon0, alt0, Ellipsoid::default());
 
         assert!((e-eref).abs()<1e-3);
         assert!((n-nref).abs()<1e-3);
@@ -946,8 +946,8 @@ mod tests {
         let elref = deg2rad(70.0);
         let rangeref = 1000.0;
 
-        let (x,y,z) = aer2ecef(azref, elref, rangeref, lat0, lon0, alt0, Reference::default());
-        let (az,el,range) = ecef2aer(x, y, z, lat0, lon0, alt0, Reference::default());
+        let (x,y,z) = aer2ecef(azref, elref, rangeref, lat0, lon0, alt0, Ellipsoid::default());
+        let (az,el,range) = ecef2aer(x, y, z, lat0, lon0, alt0, Ellipsoid::default());
 
         assert!((az-azref).abs()<1e-3);
         assert!((el-elref).abs()<1e-3);
@@ -965,8 +965,8 @@ mod tests {
         let lon0 = deg2rad(-80.5);
         let alt0 = 2.7;
 
-        let (x,y,z) = aer2eci(gst, azref, elref, rangeref, lat0, lon0, alt0, Reference::default());
-        let (az,el,range) = eci2aer(gst, x, y, z, lat0, lon0, alt0, Reference::default());
+        let (x,y,z) = aer2eci(gst, azref, elref, rangeref, lat0, lon0, alt0, Ellipsoid::default());
+        let (az,el,range) = eci2aer(gst, x, y, z, lat0, lon0, alt0, Ellipsoid::default());
 
         assert!((az-azref).abs()<1e-3);
         assert!((el-elref).abs()<1e-3);
@@ -986,7 +986,7 @@ mod tests {
         let lonref = deg2rad(-82.0);
         let altref = 1.990000000007368e+02;
 
-        let (lat,lon,alt) = ned2geodetic(n, e, d, lat0, lon0, alt0, Reference::default());
+        let (lat,lon,alt) = ned2geodetic(n, e, d, lat0, lon0, alt0, Ellipsoid::default());
 
         assert!((lat-latref).abs()<1e-8);
         assert!((lon-lonref).abs()<1e-8);
@@ -1006,7 +1006,7 @@ mod tests {
         let nref = 0.0;
         let dref = 1.0;
 
-        let (n,e,d) = geodetic2ned(lat, lon, alt, lat0, lon0, alt0, Reference::default());
+        let (n,e,d) = geodetic2ned(lat, lon, alt, lat0, lon0, alt0, Ellipsoid::default());
     
         assert!((e-eref).abs()<1e-3);
         assert!((n-nref).abs()<1e-3);
@@ -1060,7 +1060,7 @@ mod tests {
         let yref = -4.701424222957011e+06;
         let zref = 4.246579604632881e+06;
         
-        let (x,y,z) = ned2ecef(n, e, d, lat0, lon0, alt0, Reference::default());
+        let (x,y,z) = ned2ecef(n, e, d, lat0, lon0, alt0, Ellipsoid::default());
 
         assert!((x-xref).abs()<1e-3);
         assert!((y-yref).abs()<1e-3);
@@ -1069,22 +1069,22 @@ mod tests {
 
     #[test]
     fn test_ellipsoid_references() {
-        let (a, b, f, e) = Reference::Wgs84.parameters();
+        let (a, b, f, e) = Ellipsoid::Wgs84.parameters();
         assert!((a-6378137.0).abs() < 1E-6);
         assert!((b-6356752.314245).abs() < 1E-6);
         assert!((1.0/f-298.257223563).abs() < 1E-6);
         assert!((e-6.6943799E-3_f64).abs() < 1E-6);
-        let (a, b, f, e) = Reference::Zp90.parameters();
+        let (a, b, f, e) = Ellipsoid::Zp90.parameters();
         assert!((a-6378136.0).abs() < 1E-6);
         assert!((b-a*(1.0-f)).abs() < 1E-6);
         assert!((1.0/f-298.257839303).abs() < 1E-6);
         assert!((e-(f*(2.0-f))) < 1E-6);
-        let (a, b, f, e) = Reference::Grs80.parameters();
+        let (a, b, f, e) = Ellipsoid::Grs80.parameters();
         assert!((a-6378137.0).abs() < 1E-6);
         assert!((b-a*(1.0-f)).abs() < 1E-6);
         assert!((1.0/f-298.257222101).abs() < 1E-6);
         assert!((e-(f*(2.0-f))) < 1E-6);
-        let (a, b, f, e) = Reference::Bdc.parameters();
+        let (a, b, f, e) = Ellipsoid::Bdc.parameters();
         assert!((a-6378137.0).abs() < 1E-6);
         assert!((b-a*(1.0-f)).abs() < 1E-6);
         assert!((1.0/f-298.257222101).abs() < 1E-6);
@@ -1100,8 +1100,8 @@ mod tests {
         let nref = 2.868422200000000e+02;
         let dref = -9.396926200000000e+02;
         
-        let (x,y,z) = ned2ecef(nref, eref, dref, lat0, lon0, alt0, Reference::default());
-        let (n,e,d)= ecef2ned(x, y, z, lat0, lon0, alt0, Reference::default());
+        let (x,y,z) = ned2ecef(nref, eref, dref, lat0, lon0, alt0, Ellipsoid::default());
+        let (n,e,d)= ecef2ned(x, y, z, lat0, lon0, alt0, Ellipsoid::default());
 
         assert!((e-eref).abs()<1e-3);
         assert!((n-nref).abs()<1e-3);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -522,24 +522,24 @@ pub enum Ellipsoid {
     /// WGS84: GPS Ellipsoid frame  
     /// semi-major axis: 6378137.0 [m]  
     /// flattening: 1.0/298.2572235630
-    Wgs84,
+    WGS84,
     /// ZP90: Glonass Ellipsoid frame  
     /// semi-major axis: 6378136.0 [m]  
     /// flattening: 1/298.257839303
-    Zp90,
+    ZP90,
     /// BDC: Beidou Coordinate System  
     /// semi-major axis: 6378137.0 [m]  
     /// flattening: 1/298.257222101
-    Bdc,
+    BDC,
     /// GRS80 reference ellipsoid  
     /// semi-major axis: 6378137.0 [m]  
     /// flattening: 1.0/298.257222101
-    Grs80,
+    GRS80,
 }
 
 impl Default for Ellipsoid {
     fn default() -> Ellipsoid {
-        Ellipsoid::Wgs84
+        Ellipsoid::WGS84
     }
 }
 
@@ -553,10 +553,10 @@ impl Ellipsoid {
     /// - tuple.3 = squared eccentricity [rad^2]
     pub fn parameters(&self) -> (f64,f64,f64,f64) {
         let (major, flattening): (f64, f64) = match self {
-            Ellipsoid::Wgs84 => (6378137.0, 1.0/298.257223563),
-            Ellipsoid::Zp90 =>  (6378136.0, 1.0/298.257839303),
-            Ellipsoid::Bdc =>   (6378137.0, 1.0/298.257222101),
-            Ellipsoid::Grs80 => (6378137.0, 1.0/298.2572221009),
+            Ellipsoid::WGS84 => (6378137.0, 1.0/298.257223563),
+            Ellipsoid::ZP90 =>  (6378136.0, 1.0/298.257839303),
+            Ellipsoid::BDC =>   (6378137.0, 1.0/298.257222101),
+            Ellipsoid::GRS80 => (6378137.0, 1.0/298.2572221009),
         };
 
         let minor = major * (1.0 - flattening);
@@ -1069,22 +1069,22 @@ mod tests {
 
     #[test]
     fn test_ellipsoid_references() {
-        let (a, b, f, e) = Ellipsoid::Wgs84.parameters();
+        let (a, b, f, e) = Ellipsoid::WGS84.parameters();
         assert!((a-6378137.0).abs() < 1E-6);
         assert!((b-6356752.314245).abs() < 1E-6);
         assert!((1.0/f-298.257223563).abs() < 1E-6);
         assert!((e-6.6943799E-3_f64).abs() < 1E-6);
-        let (a, b, f, e) = Ellipsoid::Zp90.parameters();
+        let (a, b, f, e) = Ellipsoid::ZP90.parameters();
         assert!((a-6378136.0).abs() < 1E-6);
         assert!((b-a*(1.0-f)).abs() < 1E-6);
         assert!((1.0/f-298.257839303).abs() < 1E-6);
         assert!((e-(f*(2.0-f))) < 1E-6);
-        let (a, b, f, e) = Ellipsoid::Grs80.parameters();
+        let (a, b, f, e) = Ellipsoid::GRS80.parameters();
         assert!((a-6378137.0).abs() < 1E-6);
         assert!((b-a*(1.0-f)).abs() < 1E-6);
         assert!((1.0/f-298.257222101).abs() < 1E-6);
         assert!((e-(f*(2.0-f))) < 1E-6);
-        let (a, b, f, e) = Ellipsoid::Bdc.parameters();
+        let (a, b, f, e) = Ellipsoid::BDC.parameters();
         assert!((a-6378137.0).abs() < 1E-6);
         assert!((b-a*(1.0-f)).abs() < 1E-6);
         assert!((1.0/f-298.257222101).abs() < 1E-6);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1074,6 +1074,21 @@ mod tests {
         assert!((b-6356752.314245).abs() < 1E-6);
         assert!((1.0/f-298.257223563).abs() < 1E-6);
         assert!((e-6.6943799E-3_f64).abs() < 1E-6);
+        let (a, b, f, e) = Reference::Zp90.parameters();
+        assert!((a-6378136.0).abs() < 1E-6);
+        assert!((b-a*(1.0-f)).abs() < 1E-6);
+        assert!((1.0/f-298.257839303).abs() < 1E-6);
+        assert!((e-(f*(2.0-f))) < 1E-6);
+        let (a, b, f, e) = Reference::Grs80.parameters();
+        assert!((a-6378137.0).abs() < 1E-6);
+        assert!((b-a*(1.0-f)).abs() < 1E-6);
+        assert!((1.0/f-298.257222101).abs() < 1E-6);
+        assert!((e-(f*(2.0-f))) < 1E-6);
+        let (a, b, f, e) = Reference::Bdc.parameters();
+        assert!((a-6378137.0).abs() < 1E-6);
+        assert!((b-a*(1.0-f)).abs() < 1E-6);
+        assert!((1.0/f-298.257222101).abs() < 1E-6);
+        assert!((e-(f*(2.0-f))) < 1E-6);
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -550,8 +550,10 @@ pub enum Ellipsoid {
     /// semi-major axis: 6378136.0 [m] 
     /// flattening: 1/298.257839303
     PZ90,
-    /// BDC: Beidou Coordinate System   
-    /// semi-major axis: 6378137.0 [m] 
+    /// BDC, also known as CGCS2000,
+    /// is the reference frame used by the
+    /// Beidou constellation.  
+    /// Semi-major axis: 6378137.0 [m] 
     /// flattening: 1/298.257222101
     BDC,
     /// GRS80 reference ellipsoid  

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -546,10 +546,10 @@ pub enum Ellipsoid {
     /// WGS60: semi-major axis: 6378165.0 [m]    
     /// flattening: 1.0/298.3
     WGS60,
-    /// ZP90: Glonass Ellipsoid frame  
+    /// PZ90: Glonass Ellipsoid frame  
     /// semi-major axis: 6378136.0 [m] 
     /// flattening: 1/298.257839303
-    ZP90,
+    PZ90,
     /// BDC: Beidou Coordinate System   
     /// semi-major axis: 6378137.0 [m] 
     /// flattening: 1/298.257222101
@@ -592,7 +592,7 @@ impl Ellipsoid {
             Ellipsoid::WGS72 => (6378135.0, 1.0/298.26),
             Ellipsoid::WGS66 => (6378145.0, 1.0/298.25),
             Ellipsoid::WGS60 => (6378165.0, 1.0/298.3),
-            Ellipsoid::ZP90 =>  (6378136.0, 1.0/298.257839303),
+            Ellipsoid::PZ90 =>  (6378136.0, 1.0/298.257839303),
             Ellipsoid::BDC =>   (6378137.0, 1.0/298.257222101),
             Ellipsoid::GRS80 => (6378137.0, 1.0/298.2572221009),
             Ellipsoid::Bessel =>(6377397.155, 299.1528128),
@@ -1124,7 +1124,7 @@ mod tests {
         let (a, b, f, e) = Ellipsoid::WGS60.parameters();
         assert!((b-a*(1.0-f)).abs() < 1E-6);
         assert!((e-(f*(2.0-f))) < 1E-6);
-        let (a, b, f, e) = Ellipsoid::ZP90.parameters();
+        let (a, b, f, e) = Ellipsoid::PZ90.parameters();
         assert!((a-6378136.0).abs() < 1E-6);
         assert!((b-a*(1.0-f)).abs() < 1E-6);
         assert!((1.0/f-298.257839303).abs() < 1E-6);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -565,7 +565,7 @@ impl Reference {
     }
 }
 
-/// Returns the normal radius based for given latitude
+/// Returns the normal radius based on given latitude
 /// and desired reference frame
 pub fn get_radius_normal(lat: f64, r_ellips: Reference)->f64 {
     let (major,_,_,squared_eccentricity) = r_ellips.parameters();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1068,6 +1068,15 @@ mod tests {
     }
 
     #[test]
+    fn test_ellipsoid_references() {
+        let (a, b, f, e) = Reference::Wgs84.parameters();
+        assert!((a-6378137.0).abs() < 1E-6);
+        assert!((b-6356752.314245).abs() < 1E-6);
+        assert!((1.0/f-298.257223563).abs() < 1E-6);
+        assert!((e-6.6943799E-3_f64).abs() < 1E-6);
+    }
+
+    #[test]
     fn test_ecef2ned() {
         let lat0 = deg2rad(42.0);
         let lon0 = deg2rad(-82.0);
@@ -1108,6 +1117,3 @@ mod tests {
         assert!((expected_km - d_km).abs() < 10.0);
     }
 }
-
-
-    


### PR DESCRIPTION
Hello @gberrante how are you?

i would like to introduce the option to use a different reference ellipsoid. 
Obviously, `WGS84` is still the default value, i added an enum and we can retrieve your previous code through `Reference::default()`, what do you think?